### PR TITLE
Display voog ref only on front page of site

### DIFF
--- a/components/footer.tpl
+++ b/components/footer.tpl
@@ -11,3 +11,5 @@
     {% endif %}
   </div>
 </footer>
+
+{% include "voog-ref" %}

--- a/components/voog-ref.tpl
+++ b/components/voog-ref.tpl
@@ -1,1 +1,7 @@
-<div class="voog-reference">{% loginblock %}{{ "footer_login_link" | lc }}{% endloginblock %}</div>
+{% if site.branding.enabled and page.path == blank -%}
+  <div class="voog-reference">
+    {% loginblock %}
+      {{ "footer_login_link" | lc }}
+    {% endloginblock %}
+  </div>
+{% endif -%}

--- a/layouts/front_page.tpl
+++ b/layouts/front_page.tpl
@@ -45,7 +45,6 @@
 
     </main>
     {% include "footer" %}
-    {% include "voog-ref" %}
   </div>
   {% include "site-signout" %}
   {% include "javascripts" %}


### PR DESCRIPTION
- Voog reference is displayed only on front page of site
- Reference is displayed if branding is enabled for site
- Reference component is included to footer component to ensure it is displayed on front page, regardless of layout.

Closes #159 